### PR TITLE
Dev/vlc-compat

### DIFF
--- a/src/AviMetadataParser.java
+++ b/src/AviMetadataParser.java
@@ -1,0 +1,235 @@
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Parse metadata from an AVI file
+ *
+ * @author Emanuel Günther (s76954)
+ */
+public class AviMetadataParser {
+    private static final String LIST_STRING = "LIST";
+
+    /** Parse the AVI file and return the metadata
+     *
+     * @param filename The path of the file to parse
+     * @return Parsed metadata of the file if successful, null otherwise
+     */
+    public static VideoMetadata parse(String filename) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(filename);
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, ex.toString());
+            return null;
+        }
+
+        if (checkListHeader(fis, "RIFF", "AVI ") == -1) {
+            logger.log(Level.WARNING, "File " + filename + " is not an AVI!");
+            try {
+                fis.close();
+            } catch (Exception ex) {
+            }
+            return null;
+        }
+
+        VideoMetadata meta = parseAviHeader(fis);
+
+        try {
+            fis.close();
+        } catch (Exception ex) {
+        }
+        return meta;
+    }
+
+    /** Check if the next 8 bytes of the file are a chunk of
+     *  the specified type.
+     *
+     *  @param fis InputStream of the file
+     *  @param type Type of the chunk
+     *  @return size of the chunk if such a chunk was found, -1 otherwise
+     */
+    private static int checkChunkHeader(FileInputStream fis, String type) {
+      Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte header[] = new byte[8];
+        try {
+            int nbytes = fis.read(header);
+            if (nbytes == -1) {
+                logger.log(Level.WARNING, "EOF reached");
+                return -1;
+            }
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return -1;
+        }
+
+        String tp = new String(header, 0, 4);
+        if (!tp.equals(type)) {
+            return -1;
+        }
+
+        int size = parseInteger(Arrays.copyOfRange(header, 4, 8));
+        return size;
+    }
+
+    /** Check if the next 12 bytes of the file are a list of
+     *  the specified type.
+     *
+     *  @param fis InputStream of the file
+     *  @param label Label of the list
+     *  @param type Type of the list
+     *  @return size of the list if a list with the specified label and type was found, -1 otherwise
+     */
+    private static int checkListHeader(FileInputStream fis, String label, String type) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        int headerSize = 12;
+        byte header[] = new byte[headerSize];
+        try {
+            int nbytes = fis.read(header);
+            if (nbytes == -1) {
+                logger.log(Level.WARNING, "EOF reached");
+                return -1;
+            }
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return -1;
+        }
+        String lb = new String(header, 0, 4);
+        if (!lb.equals(label)) {
+            return -1;
+        }
+
+        int size = parseInteger(Arrays.copyOfRange(header, 4, 8));
+
+        String tp = new String(header, 8, 4);
+        if (!tp.equals(type)) {
+            return -1;
+        }
+
+        return size;
+    }
+
+    private static VideoMetadata parseAviHeader(FileInputStream fis) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        if (checkListHeader(fis, LIST_STRING, "hdrl") == -1) {
+            logger.log(Level.WARNING, "No header found");
+            return null;
+        }
+
+        // The main AVI header does not contain useful information.
+        if (!skipChunk(fis, "avih")) {
+            logger.log(Level.WARNING, "Skipping main AVI header chunk was not successful");
+            return null;
+        }
+
+        if (checkListHeader(fis, LIST_STRING, "strl") == -1) {
+            logger.log(Level.WARNING, "Stream list not found");
+            return null;
+        }
+
+        VideoMetadata meta = parseAviStreamHeaderChunk(fis);
+
+        return meta;
+    }
+
+    private static VideoMetadata parseAviStreamHeaderChunk(FileInputStream fis) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        int size = checkChunkHeader(fis, "strh");
+        if (size == -1) {
+            return null;
+        }
+
+        byte data[] = new byte[size];
+        try {
+            int nbytes = fis.read(data);
+            if (nbytes == -1) {
+                logger.log(Level.WARNING, "EOF reached");
+                return null;
+            }
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return null;
+        }
+
+        String fccType = new String(data, 0, 4);
+        String fccHandler = new String(data, 4, 8);
+        byte dwFlags[] = Arrays.copyOfRange(data, 8, 12);
+        byte wPriority[] = Arrays.copyOfRange(data, 12, 14);
+        byte wLanguage[] = Arrays.copyOfRange(data, 14, 16);
+        byte dwInitialFrames[] = Arrays.copyOfRange(data, 16, 20);
+        byte dwScale[] = Arrays.copyOfRange(data, 20, 24);
+        byte dwRate[] = Arrays.copyOfRange(data, 24, 28);
+        byte dwStart[] = Arrays.copyOfRange(data, 28, 32);
+        byte dwLength[] = Arrays.copyOfRange(data, 32, 36);
+        byte dwSuggestedBufferSize[] = Arrays.copyOfRange(data, 36, 40);
+        byte dwQuality[] = Arrays.copyOfRange(data, 40, 44);
+        byte dwSampleSize[] = Arrays.copyOfRange(data, 44, 48);
+        // RECT: long (32 bit) left, top, right, bottom
+        byte rcFrame[] = Arrays.copyOfRange(data, 48, 64);
+
+        int scale = parseInteger(dwScale);
+        int rate = parseInteger(dwRate);
+        int length = parseInteger(dwLength);
+        double fps = (double)rate / (double)scale;
+        double duration = length / fps;
+
+        return new VideoMetadata((int)fps, duration);
+    }
+
+    /** Parse an 4-byte array in little endian to int
+     *
+     * @param data 4-byte array
+     * @return Parsed value
+     */
+    private static int parseInteger(byte[] data) {
+        assert data.length == 4 : "Only 4-byte arrays are supported";
+        int val = ((data[0] & 0xFF) << 0) |
+            ((data[1] & 0xFF) << 8) |
+            ((data[2] & 0xFF) << 16) |
+            ((data[3] & 0xFF) << 24);
+        return val;
+    }
+
+    private static boolean skipChunk(FileInputStream fis, String type) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte header[] = new byte[8];
+        try {
+            int nbytes = fis.read(header);
+            if (nbytes == -1) {
+                logger.log(Level.WARNING, "EOF reached");
+                return false;
+            }
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return false;
+        }
+
+        String tp = new String(header, 0, 4);
+        if (!tp.equals(type)) {
+            return false;
+        }
+
+        int size = parseInteger(Arrays.copyOfRange(header, 4, 8));
+
+        /* AVI paddes to the next WORD boundary. A WORD has 2 bytes.
+         * Therefore if the size of the chunk (data without padding)
+         * does not conform with a WORD boundary, an additional byte
+         * has to be skipped.
+         */
+        if (size % 2 == 1) {
+            size++;
+        }
+
+        try {
+            long skipped = fis.skip(size);
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return false;
+        }
+
+        return true;
+    }
+}
+

--- a/src/Client.java
+++ b/src/Client.java
@@ -594,7 +594,7 @@ public class Client {
         if (sdur.length > 1) {
           duration = Double.parseDouble(sdur[1]);
           logger.log(Level.INFO, "duration [s]: " + duration);
-          progressPosition.setMaximum((int)duration);
+          progressPosition.setMaximum((int)duration * framerate);
         } // else: no duration available
       } // else: other attributes are not recognized here
     }

--- a/src/QuickTimeMetadataParser.java
+++ b/src/QuickTimeMetadataParser.java
@@ -1,0 +1,224 @@
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Parse metadata from an QuickTime file
+ *
+ * @author Emanuel Günther (s76954)
+ */
+public class QuickTimeMetadataParser {
+    private static final String QT_BRAND_STRING = "qt  ";
+
+    private static int timeScale = 0;
+    private static int duration = 0;
+    private static int smplCount = 0;
+    private static int smplDuration = 0;
+
+    /**
+     * Parse the QuickTime file and return the metadata
+     *
+     * @param filename The path of the file to parse
+     * @return Parsed metadata of the file if successful, null otherwise
+     */
+    public static VideoMetadata parse(String filename) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(filename);
+        } catch (Exception ex) {
+            logger.log(Level.SEVERE, ex.toString());
+            return null;
+        }
+
+        VideoMetadata meta = null;
+        while (meta == null) {
+            try {
+                meta = parseAtom(fis);
+            } catch (Exception ex) {
+                logger.log(Level.SEVERE, ex.toString());
+                return null;
+            }
+        }
+
+        return meta;
+    }
+
+    private static boolean checkFileType(FileInputStream fis, int size) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte data[] = new byte[size];
+        try {
+            int nbytes = fis.read(data);
+            if (nbytes == -1) {
+                logger.log(Level.WARNING, "EOF reached");
+                return false;
+            }
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return false;
+        }
+
+        String majorBrand = new String(data, 0, 4);
+        String minorVersion = new String(data, 4, 4);
+        boolean isQt = false;
+        for (int i = 8; i < size; i += 4) {
+            String compBrand = new String(data, i, 4);
+            if (compBrand.equals(QT_BRAND_STRING)) {
+                isQt = true;
+            }
+        }
+        return isQt;
+    }
+
+    /**
+     * Parse a single atom
+     *
+     * If an error occurs an Exception is thrown.
+     *
+     * @param fis File to be parsed
+     * @return metadata if it was found, null otherwise
+     * @throws Exception if an error occurs
+     */
+    private static VideoMetadata parseAtom(FileInputStream fis) throws Exception {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte header[] = new byte[8];
+        int nbytes = fis.read(header);
+        if (nbytes == -1) {
+            throw new Exception("EOF reached");
+        }
+
+        int size = parseInteger(Arrays.copyOfRange(header, 0, 4));
+        String type = new String(header, 4, 4);
+        size -= 8; // subtract size and type
+
+        // DEBUG:
+        // logger.log(Level.FINE, type + ": " + size);
+        switch (type) {
+            case "ftyp":
+                if (!checkFileType(fis, size)) {
+                    throw new Exception("File is not an QuickTime Movie!");
+                }
+                break;
+            case "mdhd":
+                if (!parseMediaHeaderAtom(fis, size)) {
+                    throw new Exception("Media Header Atom could not be parsed correctly");
+                }
+                break;
+            case "stts":
+                if (!parseTimeToSampleAtom(fis, size)) {
+                    throw new Exception("Time-To-Sample Atom could not be parsed correctly");
+                }
+                break;
+            // atoms to recognize, but not to skip
+            case "moov":
+            case "trak":
+            case "mdia":
+            case "minf":
+            case "stbl":
+                break;
+            // atoms to skip
+            case "dinf":
+            case "edts":
+            case "elst":
+            case "hdlr":
+            case "mdat":
+            case "mvhd":
+            case "stsd":
+            case "tkhd":
+            case "udta":
+            case "vmhd":
+            case "wide":
+                fis.skip(size);
+                break;
+            default:
+                logger.log(Level.INFO, "Atom type " + type + " not recognized");
+                fis.skip(size);
+                break;
+        }
+
+        // check if all necessary information available
+        if (timeScale != 0 && duration != 0 && smplCount != 0 && smplDuration != 0) {
+            double fps = (double)timeScale / (double)smplDuration;
+            double dur = (double)duration / (double)timeScale;
+
+            // reset all values for a possible next run
+            timeScale = 0;
+            duration = 0;
+            smplCount = 0;
+            smplDuration = 0;
+
+            return new VideoMetadata((int)fps, dur);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Parse an 4-byte array to int
+     *
+     * @param data 4-byte array
+     * @return Parsed value
+     */
+    private static int parseInteger(byte data[]) {
+        assert data.length == 4 : "Only 4-byte arrays are supported";
+        int val = ((data[0] & 0xFF) << 24) |
+        ((data[1] & 0xFF) << 16) |
+        ((data[2] & 0xFF) << 8) |
+        ((data[3] & 0xFF) << 0);
+        return val;
+    }
+
+    private static boolean parseMediaHeaderAtom(FileInputStream fis, int size) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte data[] = new byte[size];
+        try {
+            fis.read(data);
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return false;
+        }
+
+        int version = data[0];
+        byte flags[] = Arrays.copyOfRange(data, 1, 4);
+        byte creationTime[] = Arrays.copyOfRange(data, 4, 8);
+        byte modificationTime[] = Arrays.copyOfRange(data, 8, 12);
+        byte bTimeScale[] = Arrays.copyOfRange(data, 12, 16);
+        byte bDuration[] = Arrays.copyOfRange(data, 16, 20);
+        byte language[] = Arrays.copyOfRange(data, 20, 22);
+        byte quality[] = Arrays.copyOfRange(data, 22, 24);
+
+        timeScale = parseInteger(bTimeScale);
+        duration = parseInteger(bDuration);
+
+        return true;
+    }
+
+    private static boolean parseTimeToSampleAtom(FileInputStream fis, int size) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte data[] = new byte[size];
+        try {
+            fis.read(data);
+        } catch (IOException ioex) {
+            logger.log(Level.SEVERE, ioex.toString());
+            return false;
+        }
+
+        int version = data[0];
+        byte flags[] = Arrays.copyOfRange(data, 1, 4);
+        byte numberEntries[] = Arrays.copyOfRange(data, 4, 8);
+        byte ttsTable[] = Arrays.copyOfRange(data, 8, size);
+
+        int nbEntries = parseInteger(numberEntries);
+        if (nbEntries != 1) {
+            return false;
+        } else {
+            smplCount = parseInteger(Arrays.copyOfRange(ttsTable, 0, 4));
+            smplDuration = parseInteger(Arrays.copyOfRange(ttsTable, 4, 8));
+            return true;
+        }
+    }
+}
+

--- a/src/RTPpacket.java
+++ b/src/RTPpacket.java
@@ -49,7 +49,7 @@ public class RTPpacket {
     Padding = 0;
     Extension = 0;
     CC = 0;
-    Marker = 0;
+    Marker = 1;
     Ssrc = 0;
 
     // fill changing header fields:

--- a/src/Server.java
+++ b/src/Server.java
@@ -469,6 +469,9 @@ public class Server extends JFrame implements ActionListener, ChangeListener {
   private String describe() {
     StringWriter rtspHeader = new StringWriter();
     StringWriter rtspBody = new StringWriter();
+    int framerate = 25;
+    double duration = 0.0; // seconds
+
 
     // Write the body first so we can get the size later
     rtspBody.write("v=0" + CRLF);

--- a/src/Server.java
+++ b/src/Server.java
@@ -296,8 +296,9 @@ public class Server extends JFrame implements ActionListener, ChangeListener {
         frame = jpegFrame.getAsRfc2435Bytes();
 
         // Builds an RTPpacket object containing the frame
+        // time has to be in scale with 90000 Hz (RFC 2435, 3.)
         RTPpacket rtp_packet =
-            new RTPpacket(MJPEG_TYPE, imagenb, imagenb * DEFAULT_FRAME_PERIOD, frame, frame.length);
+            new RTPpacket(MJPEG_TYPE, imagenb, imagenb * (90000 / videoMeta.getFramerate()), frame, frame.length);
 
         // retrieve the packet bitstream as array of bytes
         packet_bits = rtp_packet.getpacket();

--- a/src/Server.java
+++ b/src/Server.java
@@ -520,6 +520,9 @@ public class Server extends JFrame implements ActionListener, ChangeListener {
       case "avi":
         meta = AviMetadataParser.parse(filename);
         break;
+      case "mov":
+        meta = QuickTimeMetadataParser.parse(filename);
+        break;
       default:
         logger.log(Level.WARNING, "File extension not recognized: " + filename);
       case "mjpg":

--- a/src/VideoMetadata.java
+++ b/src/VideoMetadata.java
@@ -1,0 +1,26 @@
+/** Structure holding metadata of video files
+ *
+ * @author Emanuel Günther (s76954)
+ */
+public class VideoMetadata {
+    private int framerate;
+    private double duration; // in seconds
+
+    public VideoMetadata(int framerate, double duration) {
+        this.framerate = framerate;
+        this.duration = duration;
+    }
+
+    public VideoMetadata(int framerate) {
+        this(framerate, 0.0);
+    }
+
+    public int getFramerate() {
+        return this.framerate;
+    }
+
+    public double getDuration() {
+        return this.duration;
+    }
+}
+


### PR DESCRIPTION
Restore compatibility with VLC Media Player

Using the own RTSP server to send a Video an receive it with the VLC Media Player was possible some time ago.
But it is impossible for recent VLC Media Player versions.
The proposed changes add some information to the SDP as response to a DESCRIBE request.
Also the RTSP request parser is improved to not rely on a specific order of message fields anymore.
Additionally parsers for AVI and QuickTime files are provided to extract details about framerate and duration of a video.
Finally, by changing the timestamp and the marker in all RTP packets, the compatibility with the VLC Media Player is restored.