### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# global owner
+* @HTWDD-SN
+


### PR DESCRIPTION
Add a CODEOWNERS file to make Githubs branch protection work.