### PR TITLE
Refactor RTP processing with moving it to `RtpHandler`

### DIFF
--- a/Projektbeschreibung.md
+++ b/Projektbeschreibung.md
@@ -7,19 +7,26 @@ Ihre Aufgabe besteht im Wesentlichen aus der Ergänzung der Quellcodes in den Pu
 * FEC in Client, Paketkorrektur implementierne
 
 ## 1. Java-Klassen
-Das Projekt besteht aus folgenden Java-Klassen:
+Das Projekt besteht aus mehreren Java-Klassen, die je nach Funktionsumfang für Client, Server oder auch beide Anwendungen eingesetzt werden.
 
-[Client](src/Client.java): Funktionalität des Clients mit Benutzerschnittstelle zum Senden der RTSP-Kommandos und Anzeige des Videos  
-[Server](src/Server.java): Funktionalität des Servers zur Antwort auf die RTSP-Clientanfragen und Streaming des Videos  
-[RTPpacket](src/RTPpacket.java): Funktionalität zur Unterstützung von RTP-Paketen  
-[FECpacket](src/FECpacket.java): Erweiterung der RTP-Klasse mit FEC-Funktionalität  
-[FecHandler](src/FecHandler.java): Unterstützung der Fehlerkorrektur mittels FEC  
-[VideoReader](src/VideoReader.java): Einlesen einer MJPEG-Datei auf der Serverseite  
-[JpegFrame](src/JpegFrame): Codierung/Decodierung von JPEG-Bildern gemäß RFC-2435  
-[AviMetadataParser](src/AviMetadataParser.java): Extrahiert Metadaten aus AVI-Dateien  
-[CustomLoggingHandler](src/CustomLoggingHandler.java): Anpassung der Logger-Ausgaben für minimalen Overhead  
-[QuickTimeMetadataParser](src/QuickTimeMetadataParser.java): Extrahiert Metadaten aus Quicktime-Movie-Dateien  
-[VideoMetadata](src/VideoMetadata.java): Video-Metadaten wie Framerate und Abspieldauer
+### Server-seitige Klassen
+* [AviMetadataParser](AviMetadataParser.java): Extrahiert Metadaten aus AVI-Dateien
+* [QuickTimeMetadataParser](QuickTimeMetadataParser.java): Extrahiert Metadaten aus Quicktime-Movie-Dateien
+* [Server](src/Server.java): Funktionalität des Servers zur Antwort auf die RTSP-Clientanfragen und Streaming des Videos
+* [VideoReader](src/VideoReader.java): Einlesen einer MJPEG-Datei auf der Serverseite
+
+### Client-seitige Klassen
+* [Client](src/Client.java): Funktionalität des Clients mit Benutzerschnittstelle zum Senden der RTSP-Kommandos und Anzeige des Videos
+* [ReceptionStatistic](src/ReceptionStatistic.java): Bereitstellung von Empfangsstatistiken
+
+### Klassen für Server und Client
+* [CustomLoggingHandler](CustomLoggingHandler.java): Anpassung der Logger-Ausgaben für minimalen Overhead
+* [FecHandler](src/FecHandler.java): Unterstützung der Fehlerkorrektur mittels FEC
+* [FECpacket](src/FECpacket.java): Erweiterung der RTP-Klasse mit FEC-Funktionalität
+* [JpegFrame](src/JpegFrame): Codierung/Decodierung von JPEG-Bildern gemäß RFC-2435
+* [RTPpacket](src/RTPpacket.java): Funktionalität zur Unterstützung von RTP-Paketen
+* [VideoMetadata](VideoMetadata.java): Video-Metadaten wie Framerate und Abspieldauer
+* [RtpHandler](src/RtpHandler.java): Verarbeitung von RTP-Paketen
 
 ## 2. Programmstart
 Der Start des Servers erfolgt mittels `java Server RTSP-Port`. Der Standard-RTSP-Port ist 554, da Sie aber im Praktikum einen Port > 1024 nutzen müssen, bietet sich der alternative Port 8554 an. Der Start des Clients erfolgt mittels `java Client server_name server_port video_file`. Am Client können RTSP-Kommandos angefordert werden. 

--- a/src/FecHandler.java
+++ b/src/FecHandler.java
@@ -19,11 +19,9 @@ public class FecHandler {
   FECpacket fec;
 
   // Receiver
-  HashMap<Integer, RTPpacket> rtpStack = new HashMap<>(); // list of media packets
   HashMap<Integer, FECpacket> fecStack = new HashMap<>(); // list of fec packets
   HashMap<Integer, Integer> fecNr = new HashMap<>(); // Snr of corresponding fec packet
   HashMap<Integer, List<Integer>> fecList = new HashMap<>(); // list of involved media packets
-  HashMap<Integer, List<Integer>> tsList = new HashMap<>(); // media packets with same ts
 
   int playCounter = 0; // SNr of RTP-packet to play next, initialized with first received packet
 
@@ -124,39 +122,11 @@ public class FecHandler {
   // *************** Receiver PUT *****************************************************************
 
   /**
-   * Handles and store a received media packet
-   *
-   * @param rtp the received RTP
-   */
-  public void rcvRtpPacket(RTPpacket rtp) {
-    Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-    int seqNr = rtp.getsequencenumber();
-    // if first packet set playcounter below seqNr
-    if (rtpStack.size() == 0) playCounter = seqNr - 1;
-    // separate Media an FEC
-    if (rtp.getpayloadtype() == MJPEG) {
-      nrReceived++; // count only media
-      rtpStack.put(seqNr, rtp);
-      lastReceivedSeqNr = seqNr;
-      // create list of RTPs with same time stamp
-      int ts = rtp.gettimestamp();
-      List<Integer> list = tsList.get(ts);
-      if (list == null) list = new ArrayList<>();
-      list.add(seqNr);
-      tsList.put( ts, list );
-      logger.log(Level.FINER, "FEC: set media nr: " + seqNr);
-      logger.log(Level.FINER, "FEC: set ts-list: " + (0xFFFFFFFFL & ts) + " " + list.toString());
-    } else {
-      rcvFecPacket(rtp);
-    }
-  }
-
-  /**
    * Handles and store a recieved FEC packet
    *
    * @param rtp the received FEC-RTP
    */
-  private void rcvFecPacket(RTPpacket rtp) {
+  public void rcvFecPacket(RTPpacket rtp) {
     Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
     // build fec from rtp
     fec = new FECpacket(rtp.getpacket(), rtp.getpacket().length);
@@ -180,105 +150,12 @@ public class FecHandler {
   // *************** Receiver GET *****************************************************************
 
   /**
-   * Delivers next Frame, depreciated, see getNextRtpList
-   *
-   * @return JPEG
-   */
-  public byte[] getNextFrame() {
-    playCounter++;
-    if (playCounter > lastReceivedSeqNr) {
-      return null; // Jitter buffer is empty -> finish
-    }
-    RTPpacket rtp = getNextRtp();
-
-    clearStack(playCounter); // reduce the stack
-
-    if (rtp == null) {
-      return lastPayload; // error concealment
-    } else {
-      lastPayload = rtp.getpayload();
-      return rtp.getpayload();
-    }
-  }
-
-  /**
-   * Delivers next RTP packet,
-   *
-   * @return RTPpacket
-   */
-  private RTPpacket getNextRtp() {
-    return getRtp(playCounter);
-  }
-
-  /**
-   * Delivers a RTP packet
-   *
-   * @return RTPpacket
-   */
-  private RTPpacket getRtp(int snr) {
-    Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-    snr = snr % 0x10000; // account overflow of SNr (16 Bit)
-    RTPpacket rtp = rtpStack.get(snr);
-    logger.log(Level.FINE, "FEC: get RTP nr: " + snr);
-
-    // check if correction is possible
-    if (rtp == null) {
-      logger.log(Level.WARNING, "FEC: Media lost: " + snr);
-      nrLost++;
-      if (checkCorrection(snr) && useFec) {
-        nrCorrected++;
-        logger.log(Level.INFO, "---> FEC: correctable: " + snr);
-        return correctRtp(snr);
-      } else {
-        nrNotCorrected++;
-        logger.log(Level.INFO, "---> FEC: not correctable: " + snr);
-        return null;
-      }
-    }
-    return rtp;
-  }
-
-  /**
-   * Delivers a set of RTPs with the same Time stamp the set is in the correct order concerning the
-   * sequence number
-   *
-   * @return List
-   */
-  public ArrayList<RTPpacket> getNextRtpList() {
-    Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-    nrFramesRequested++;
-    playCounter++;
-    ArrayList<RTPpacket> list = new ArrayList<>();
-    RTPpacket rtp = getNextRtp();
-    // check for lost rtp
-    if (rtp == null) {
-      nrFramesLost++;
-      return null;
-    }
-    list.add(rtp);
-    int ts = rtp.gettimestamp();
-    List<Integer> rtpList = tsList.get(ts); // list of RTPs with same time stamp
-    if (rtpList == null) return list; // if list is empty
-
-    //TODO lost RTPs are not in the list but could perhaps be corrected -> check for snr
-    //add all RTPs but the first which is already included
-    for (int i = 1; i < rtpList.size(); i++) {
-      list.add( getRtp(rtpList.get(i) ));
-    }
-    playCounter = playCounter + rtpList.size()-1; // set to snr of last packet
-    //TODO if list is fragmented return null or implement JPEG error concealment
-
-    logger.log(Level.FINER, "-> Get list of " + list.size() + " RTPs with TS: " + (0xFFFFFFFFL & ts));
-    return list;
-  }
-
-  /**
    * Checks if the RTP packet is reparable
    *
    * @param nr Sequence Nr.
    * @return true if possible
    */
-  private boolean checkCorrection(int nr) {
+  public boolean checkCorrection(int nr, HashMap<Integer, RTPpacket> mediaPackets) {
     //TASK complete this method!
     return false;
   }
@@ -289,7 +166,7 @@ public class FecHandler {
    * @param nr Sequence Nr.
    * @return RTP packet
    */
-  private RTPpacket correctRtp(int nr) {
+  public RTPpacket correctRtp(int nr, HashMap<Integer, RTPpacket> mediaPackets) {
     //TASK complete this method!
     return fec.getLostRtp(nr);
   }

--- a/src/ReceptionStatistic.java
+++ b/src/ReceptionStatistic.java
@@ -1,0 +1,16 @@
+/**
+ * Class for statistic values of the RTP packet reception.
+ *
+ * @author Emanuel Günther
+ */
+public class ReceptionStatistic {
+    public int correctedPackets = 0;
+    public int framesLost = 0;
+    public int notCorrectedPackets = 0;
+    public int packetsLost = 0;
+    public int playbackIndex = -1;
+    public int receivedPackets = 0;
+    public int requestedFrames = 0;
+    public int latestSequenceNumber = -1;
+}
+

--- a/src/RtpHandler.java
+++ b/src/RtpHandler.java
@@ -1,3 +1,6 @@
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -9,6 +12,7 @@ import java.util.logging.Logger;
  * @author Emanuel Günther
  */
 public class RtpHandler {
+    public static final int RTP_PAYLOAD_FEC = 127; // assumed as in RFC 5109, 10.1
     public static final int RTP_PAYLOAD_JPEG = 26;
 
     private FecHandler fecHandler = null;
@@ -16,6 +20,13 @@ public class RtpHandler {
     // server side
     private int currentSeqNb = 0; // sequence number of current frame
     private boolean fecEncodingEnabled = false; // server side
+
+    // client side
+    private boolean fecDecodingEnabled = false; // client side
+    private HashMap<Integer, RTPpacket> mediaPackets = null;
+    private int playbackIndex = -1;
+    private HashMap<Integer, List<Integer>> sameTimestamps = null;
+    private ReceptionStatistic statistics = null;
 
     /**
      * Create a new RtpHandler as server.
@@ -30,6 +41,19 @@ public class RtpHandler {
     }
 
     /**
+     * Create a new RtpHandler as client.
+     *
+     * @param useFec Use FEC correction or not
+     */
+    public RtpHandler(boolean useFec) {
+        fecDecodingEnabled = useFec;
+        fecHandler = new FecHandler(useFec);
+        mediaPackets = new HashMap<>();
+        sameTimestamps = new HashMap<>();
+        statistics = new ReceptionStatistic();
+    }
+
+    /**
      * Retrieve the current FEC packet, if it is available.
      *
      * @return FEC packet as byte array, null if no such packet available
@@ -41,6 +65,18 @@ public class RtpHandler {
 
         byte[] fecPacket = fecHandler.getPacket();
         return fecPacket;
+    }
+
+    /**
+     * Get statistic values of the reception of the packets.
+     *
+     * @return Object with statistic values
+     */
+    public ReceptionStatistic getReceptionStatistic() {
+        // update values which are used internally and that are not just statistic
+        statistics.playbackIndex = playbackIndex;
+
+        return statistics;
     }
 
     /**
@@ -87,12 +123,158 @@ public class RtpHandler {
     }
 
     /**
+     * Get next image for playback.
+     *
+     * This method is the main interface for continuously getting images
+     * for the purpose of displaying them.
+     *
+     * @return Image as byte array
+     */
+    public byte[] nextPlaybackImage() {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        statistics.requestedFrames++;
+        playbackIndex++;
+
+        ArrayList<RTPpacket> packetList = packetsForNextImage();
+        if (packetList == null) {
+            return null;
+        }
+
+        byte[] image = JpegFrame.combineToOneImage(packetList);
+        logger.log(Level.FINE, "Display TS: "
+                + (packetList.get(0).gettimestamp() & 0xFFFFFFFFL)
+                + " size: " + image.length);
+
+        return image;
+    }
+
+    /**
+     * Process and store a received RTP packet.
+     *
+     * @param packetData the received RTP packet as byte array
+     */
+    public void processRtpPacket(byte[] packetData, int packetLength) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        RTPpacket packet = new RTPpacket(packetData, packetLength);
+        int seqNr = packet.getsequencenumber();
+
+        // set the correct index for beginning the playback
+        if (playbackIndex == -1) {
+            playbackIndex = seqNr - 1;
+        }
+
+        int pt = packet.getpayloadtype();
+
+        if (pt == RTP_PAYLOAD_JPEG) {
+            statistics.receivedPackets++;
+            statistics.latestSequenceNumber = seqNr;
+            mediaPackets.put(seqNr, packet);
+
+            int ts = packet.gettimestamp();
+            List<Integer> tmpTimestamps = sameTimestamps.get(ts);
+            if (tmpTimestamps == null) {
+                tmpTimestamps = new ArrayList<>();
+            }
+            tmpTimestamps.add(seqNr);
+            sameTimestamps.put(ts, tmpTimestamps);
+            logger.log(Level.FINER, "FEC: set media nr: " + seqNr);
+            logger.log(Level.FINER, "FEC: set sameTimestamps: " + (0xFFFFFFFFL & ts)
+                    + " " + tmpTimestamps.toString());
+        } else if (pt == RTP_PAYLOAD_FEC) {
+            fecHandler.rcvFecPacket(packet);
+        }
+        // else: ignore packet
+
+        logger.log(Level.FINER,
+                "---------------- Receiver -----------------------"
+                + "\r\n"
+                + "Got RTP packet with SeqNum # "
+                + packet.getsequencenumber()
+                + " TimeStamp: "
+                + (0xFFFFFFFFL & packet.gettimestamp()) // cast to long
+                + " ms, of type "
+                + pt
+                + " Size: " + packet.getlength());
+
+        // TASK remove comment for debugging
+        // packet.printheader(); // print rtp header bitstream for debugging
+    }
+
+    /**
      * Set a new group size for the FEC error handling.
      *
      * @param newGroupSize new group size
      */
     public void setFecGroupSize(int newGroupSize) {
         fecHandler.setFecGroupSize(newGroupSize);
+    }
+
+    /**
+     * Get the RTP packet with the given sequence number.
+     *
+     * This is the main method for getting RTP packets. It currently
+     * includes error correction via FEC, but can be extended in future.
+     *
+     * @param number Sequence number of the RTP packet
+     * @return RTP packet, null if not available and not correctable
+     */
+    private RTPpacket obtainMediaPacket(final int number) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        int index = number % 0x10000; // account overflow of SNr (16 Bit)
+        RTPpacket packet = mediaPackets.get(index);
+        logger.log(Level.FINE, "FEC: get RTP nu: " + index);
+
+        if (packet == null) {
+            statistics.packetsLost++;
+            logger.log(Level.WARNING, "FEC: Media lost: " + index);
+
+            boolean fecCorrectable = fecHandler.checkCorrection(index, mediaPackets);
+            if (fecDecodingEnabled && fecCorrectable) {
+                packet = fecHandler.correctRtp(index, mediaPackets);
+                statistics.correctedPackets++;
+                logger.log(Level.INFO, "---> FEC: correctable: " + index);
+            } else {
+                statistics.notCorrectedPackets++;
+                logger.log(Level.INFO, "---> FEC: not correctable: " + index);
+                return null;
+            }
+        }
+
+        return packet;
+    }
+
+    /**
+     * Construct a list of RTP packets which contain the data of one image.
+     *
+     * @return List of RTP packets for one image
+     */
+    private ArrayList<RTPpacket> packetsForNextImage() {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        ArrayList<RTPpacket> packetList = new ArrayList<>();
+        RTPpacket packet = obtainMediaPacket(playbackIndex);
+        if (packet == null) {
+            statistics.framesLost++;
+            return null;
+        }
+
+        packetList.add(packet);
+        int timestamp = packet.gettimestamp();
+        List<Integer> timestamps = sameTimestamps.get(timestamp);
+        if (timestamps == null) {
+            return packetList;
+        }
+
+        // TODO lost RTPs are not in the list but could perhaps be corrected -> check for snr
+        for (int i = 1; i < timestamps.size(); i++) {
+            packetList.add(obtainMediaPacket(timestamps.get(i)));
+        }
+
+        playbackIndex += timestamps.size() - 1;
+        // TODO if list is fragmented return null or implement JPEG error concealment
+
+        logger.log(Level.FINER, "-> Get list of " + packetList.size()
+                + " RTPs with TS: " + (0xFFFFFFFFL & timestamp));
+        return packetList;
     }
 }
 

--- a/src/RtpHandler.java
+++ b/src/RtpHandler.java
@@ -1,0 +1,98 @@
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Handler for RTP packets.
+ *
+ * Processes all RTP packets and provides JPEG images for displaying
+ *
+ * @author Emanuel Günther
+ */
+public class RtpHandler {
+    public static final int RTP_PAYLOAD_JPEG = 26;
+
+    private FecHandler fecHandler = null;
+
+    // server side
+    private int currentSeqNb = 0; // sequence number of current frame
+    private boolean fecEncodingEnabled = false; // server side
+
+    /**
+     * Create a new RtpHandler as server.
+     *
+     * @param fecGroupSize Group size for FEC packets. If the value is 0, FEC will be disabled.
+     */
+    public RtpHandler(int fecGroupSize) {
+        if (fecGroupSize > 0) {
+            fecEncodingEnabled = true;
+            fecHandler = new FecHandler(fecGroupSize);
+        }
+    }
+
+    /**
+     * Retrieve the current FEC packet, if it is available.
+     *
+     * @return FEC packet as byte array, null if no such packet available
+     */
+    public byte[] createFecPacket() {
+        if (!isFecPacketAvailable()) {
+            return null;
+        }
+
+        byte[] fecPacket = fecHandler.getPacket();
+        return fecPacket;
+    }
+
+    /**
+     * Check for the availability of an FEC packet.
+     *
+     * @return bolean value if FEC packet available
+     */
+    public boolean isFecPacketAvailable() {
+        if (fecEncodingEnabled) {
+            return fecHandler.isReady();
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Transform a JPEG image to an RTP packet.
+     *
+     * Takes care of all steps inbetween.
+     *
+     * @param jpegImage JPEG image as byte array
+     * @return RTP packet as byte array
+     */
+    public byte[] jpegToRtpPacket(final byte[] jpegImage, int framerate) {
+        Logger logger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        byte[] payload;
+        JpegFrame frame = JpegFrame.getFromJpegBytes(jpegImage);
+        payload = frame.getAsRfc2435Bytes();
+
+        currentSeqNb++;
+
+        // Build an RTPpacket object containing the image
+        // time has to be in scale with 90000 Hz (RFC 2435, 3.)
+        RTPpacket packet = new RTPpacket(
+                RTP_PAYLOAD_JPEG, currentSeqNb,
+                currentSeqNb * (90000 / framerate),
+                payload, payload.length);
+
+        if (fecEncodingEnabled) {
+            fecHandler.setRtp(packet);
+        }
+
+        return packet.getpacket();
+    }
+
+    /**
+     * Set a new group size for the FEC error handling.
+     *
+     * @param newGroupSize new group size
+     */
+    public void setFecGroupSize(int newGroupSize) {
+        fecHandler.setFecGroupSize(newGroupSize);
+    }
+}
+


### PR DESCRIPTION
To improve the extensibility of the project the RTP processing of server and client side is moved to a new class `RtpHandler`.
This creates a clean and simple interface for both applications and also hides implementation details from them.
Previously server and client handled a lot of the RTP processing themselves.

The new created structure enables a simpler extension of the RTP functionality, e.g. as needed for encryption support.
The `FecHandler` now is arranged as supporting class of `RtpHandler` and so does not have to implement RTP processing.

Along with the refactoring the documentation in `Aufgabenstellung.md` and `Projektbeschreibung.md` is updated and slightly improved (see [this commit](https://github.com/HTWDD-RN/RTSP-Streaming/commit/38c1418da1274a48ddfbba37f953e216b55fe6ef)).

The compatibility with the VLC Media Player was tested and is granted.