### PR TITLE
Implement an (insecure) example of JPEG encryption

### DIFF
--- a/Projektbeschreibung.md
+++ b/Projektbeschreibung.md
@@ -28,7 +28,7 @@ Das Projekt besteht aus mehreren Java-Klassen, die je nach Funktionsumfang für 
 * [VideoMetadata](VideoMetadata.java): Video-Metadaten wie Framerate und Abspieldauer
 * [RtpHandler](src/RtpHandler.java): Verarbeitung von RTP-Paketen
 * [SrtpHandler](src/SrtpHandler.java): Verschlüsselung von RTP-Paketen
-
+* [JpegEncryptionHandler](src/JpegEncryptionHandler.java): Verschlüsselung von JPEG-Bildern (Quantisierungstabellen)
 
 
 ## 2. Programmstart

--- a/src/Client.java
+++ b/src/Client.java
@@ -657,6 +657,11 @@ public class Client {
     encryptionButtons.add(e_jpeg);
     panel.add(e_jpeg);
 
+    JRadioButton a_jpeg = new JRadioButton("JPEG (Angriff)");
+    a_jpeg.addItemListener(this::radioButtonSelected);
+    encryptionButtons.add(a_jpeg);
+    panel.add(a_jpeg);
+
     return panel;
   }
 
@@ -672,6 +677,9 @@ public class Client {
         break;
       case "JPEG":
         mode = RtpHandler.EncryptionMode.JPEG;
+        break;
+      case "JPEG (Angriff)":
+        mode = RtpHandler.EncryptionMode.JPEG_ATTACK;
         break;
       default:
         break;

--- a/src/Client.java
+++ b/src/Client.java
@@ -652,6 +652,11 @@ public class Client {
     encryptionButtons.add(e_srtp);
     panel.add(e_srtp);
 
+    JRadioButton e_jpeg = new JRadioButton("JPEG");
+    e_jpeg.addItemListener(this::radioButtonSelected);
+    encryptionButtons.add(e_jpeg);
+    panel.add(e_jpeg);
+
     return panel;
   }
 
@@ -664,6 +669,9 @@ public class Client {
       switch (label) {
       case "SRTP":
         mode = RtpHandler.EncryptionMode.SRTP;
+        break;
+      case "JPEG":
+        mode = RtpHandler.EncryptionMode.JPEG;
         break;
       default:
         break;

--- a/src/JpegEncryptionHandler.java
+++ b/src/JpegEncryptionHandler.java
@@ -1,3 +1,5 @@
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.security.Key;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -225,6 +227,52 @@ public class JpegEncryptionHandler {
         }
 
         return dqtFound;
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            System.out.println("To run the tests for this encryption, specify a JPEG file.");
+            return;
+        }
+
+        FileInputStream fis = new FileInputStream(args[0]);
+        byte[] plainImage = new byte[fis.available()];
+        fis.read(plainImage);
+
+        byte[] key = new byte[]{
+            (byte)0xE1, (byte)0xF9, (byte)0x7A, (byte)0x0D, (byte)0x3E, (byte)0x01, (byte)0x8B, (byte)0xE0,
+            (byte)0xD6, (byte)0x4F, (byte)0xA3, (byte)0x2C, (byte)0x06, (byte)0xDE, (byte)0x41, (byte)0x39};
+        byte[] salt = new byte[]{
+            (byte)0x0E, (byte)0xC6, (byte)0x75, (byte)0xAD, (byte)0x49, (byte)0x8A, (byte)0xFE,
+            (byte)0xEB, (byte)0xB6,	(byte)0x96, (byte)0x0B, (byte)0x3A, (byte)0xAB, (byte)0xE6};
+        JpegEncryptionHandler jeh = new JpegEncryptionHandler(key, salt);
+
+        byte[] cipherImage = jeh.encrypt(plainImage);
+        if (cipherImage != null) {
+            FileOutputStream cipherFos = new FileOutputStream("encrypted.jpeg");
+            cipherFos.write(cipherImage);
+        } else {
+            System.out.println("Error at encrypting the image.");
+        }
+
+        byte[] decryptedImage = jeh.decrypt(cipherImage);
+        if (decryptedImage != null) {
+            FileOutputStream decFos = new FileOutputStream("decrypted.jpeg");
+            decFos.write(decryptedImage);
+        } else {
+            System.out.println("Error at decrypting the image.");
+        }
+    }
+
+    public static String hexdump(byte[] data) {
+        String b = "";
+        for (int i = 0; i < data.length; i++) {
+            b += String.format("%2s", Integer.toHexString(data[i] & 0xFF)).replace(' ', '0');
+            if (data.length > 16 && (i + 1) % 16 == 0 && i != 0) {
+                b += "\n";
+            }
+        }
+        return b;
     }
 }
 

--- a/src/JpegEncryptionHandler.java
+++ b/src/JpegEncryptionHandler.java
@@ -1,0 +1,153 @@
+/**
+ * Encrypting JPEG images after compression.
+ *
+ * @author Emanuel Günther
+ */
+public class JpegEncryptionHandler {
+    private static final byte JPEG_ZERO = (byte)0x00;
+    private static final byte JPEG_MARKER = (byte)0xFF;
+    private static final byte JPEG_SOI = (byte)0xD8;
+    private static final byte JPEG_EOI = (byte)0xD9;
+    private static final byte JPEG_DQT = (byte)0xDB;
+
+    private byte[] encryptionKey = null;
+    private byte[] encryptionSalt = null;
+    private byte[] inImage = null;
+    private byte[] outImage = null;
+    private int position = 0;
+
+    /**
+     * Create a new JpegEncryptionHandler.
+     *
+     * @param key the key for encryption and decryption
+     * @param salt salt for determining the input vector for encryption and decryption
+     */
+    public JpegEncryptionHandler(byte[] key, byte[] salt) {
+        assert key.length == 16 : "Key has to be 16 Bytes.";
+        assert salt.length == 14 : "Salt has to be 14 Bytes.";
+
+        encryptionKey = key;
+        encryptionSalt = salt;
+    }
+
+    /**
+     * Decrypt an encrypted JPEG image.
+     *
+     * @param image the encrypted image
+     * @return the decrypted image, or null if decryption failed
+     */
+    public byte[] decrypt(byte[] image) {
+        position = 0;
+        inImage = image;
+        outImage = new byte[image.length];
+
+        if (!seekToDqt()) {
+            return null;
+        }
+        System.arraycopy(inImage, 0, outImage, 0, position);
+
+        if (!cryptDqt(false)) {
+            return null;
+        }
+
+        // copy remaining data
+        copyData(inImage.length - position);
+
+        return outImage;
+    }
+
+    /**
+     * Encrypt an encrypted JPEG image.
+     *
+     * @param image the image
+     * @return the encrypted image, or null if encryption failed
+     */
+    public byte[] encrypt(byte[] image) {
+        position = 0;
+        inImage = image;
+        outImage = new byte[image.length];
+
+        if (!seekToDqt()) {
+            return null;
+        }
+        System.arraycopy(inImage, 0, outImage, 0, position);
+
+        if (!cryptDqt(true)) {
+            return null;
+        }
+
+        // copy remaining data
+        copyData(inImage.length - position);
+
+        return outImage;
+    }
+
+    /**
+     * Copy data from input image to output image.
+     *
+     * The data beginning from "position" is copied in the length
+     * of "length". Also the member variable "position" is increased
+     * by the amount of copied bytes.
+     *
+     * @param length size of data to copy
+     */
+    private void copyData(int length) {
+        System.arraycopy(inImage, position, outImage, position, length);
+        position += length;
+    }
+
+    /**
+     * Encrypt or decrypt the quantization tables.
+     *
+     * The position is required to be at the DQT marker.
+     * Processed are just the quantization table elements, not the
+     * precision nor the destination identifier.
+     *
+     * @param encryption Has to be true, if the tables should be encrypted; false indicates decryption.
+     * @return true if cryptographic operation was successful, false otherwise
+     */
+    private boolean cryptDqt(boolean encryption) {
+        return false;
+    }
+
+    /**
+     * Seek to the next quantization table segment.
+     *
+     * @return true if skip successfull, false otherwise
+     */
+    private boolean seekToDqt() {
+        boolean marker = false;
+        boolean eoiFound = false;
+        boolean dqtFound = false;
+
+        while (!eoiFound && !dqtFound) {
+            if (marker) {
+                switch (inImage[position]) {
+                case JPEG_MARKER:
+                    break;
+                case JPEG_DQT:
+                    dqtFound = true;
+                    position -= 2; // start at marker and revert increment
+                    break;
+                case JPEG_EOI:
+                    eoiFound = true;
+                    break;
+                default:
+                    marker = false;
+                    break;
+                }
+            } else {
+                switch (inImage[position]) {
+                case JPEG_MARKER:
+                    marker = true;
+                    break;
+                }
+            }
+
+            position++;
+        }
+
+        return dqtFound;
+    }
+}
+

--- a/src/JpegEncryptionHandler.java
+++ b/src/JpegEncryptionHandler.java
@@ -76,21 +76,23 @@ public class JpegEncryptionHandler {
      * @return the decrypted image, or null if decryption failed
      */
     public byte[] decrypt(byte[] image) {
+        int startPos = 0;
         position = 0;
         inImage = image;
         outImage = new byte[image.length];
 
-        if (!seekToDqt()) {
-            return null;
-        }
-        System.arraycopy(inImage, 0, outImage, 0, position);
+        while (seekToDqt()) {
+            System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
-        if (!cryptDqt(false)) {
-            return null;
+            if (!cryptDqt(false)) {
+                return null;
+            }
+
+            startPos = position;
         }
 
         // copy remaining data
-        copyData(inImage.length - position);
+        System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
         return outImage;
     }
@@ -102,21 +104,23 @@ public class JpegEncryptionHandler {
      * @return the encrypted image, or null if encryption failed
      */
     public byte[] encrypt(byte[] image) {
+        int startPos = 0;
         position = 0;
         inImage = image;
         outImage = new byte[image.length];
 
-        if (!seekToDqt()) {
-            return null;
-        }
-        System.arraycopy(inImage, 0, outImage, 0, position);
+        while (seekToDqt()) {
+            System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
-        if (!cryptDqt(true)) {
-            return null;
+            if (!cryptDqt(true)) {
+                return null;
+            }
+
+            startPos = position;
         }
 
         // copy remaining data
-        copyData(inImage.length - position);
+        System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
         return outImage;
     }
@@ -131,21 +135,23 @@ public class JpegEncryptionHandler {
      * @return the image with the replaced DQT tables, or null if it failed
      */
     public byte[] replaceAttackDecryption(byte[] image) {
+        int startPos = 0;
         position = 0;
         inImage = image;
         outImage = new byte[image.length];
 
-        if (!seekToDqt()) {
-            return null;
-        }
-        System.arraycopy(inImage, 0, outImage, 0, position);
+        while (seekToDqt()) {
+            System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
-        if (!replaceDqtTables()) {
-            return null;
+            if (!replaceDqtTables()) {
+                return null;
+            }
+
+            startPos = position;
         }
 
         // copy remaining data
-        copyData(inImage.length - position);
+        System.arraycopy(inImage, startPos, outImage, startPos, position - startPos);
 
         return outImage;
     }

--- a/src/RtpHandler.java
+++ b/src/RtpHandler.java
@@ -16,7 +16,8 @@ import java.util.logging.Logger;
 public class RtpHandler {
     public enum EncryptionMode {
         NONE,
-        SRTP
+        SRTP,
+        JPEG
     }
 
     public static final int RTP_PAYLOAD_FEC = 127; // assumed as in RFC 5109, 10.1

--- a/src/RtpHandler.java
+++ b/src/RtpHandler.java
@@ -17,7 +17,8 @@ public class RtpHandler {
     public enum EncryptionMode {
         NONE,
         SRTP,
-        JPEG
+        JPEG,
+        JPEG_ATTACK
     }
 
     public static final int RTP_PAYLOAD_FEC = 127; // assumed as in RFC 5109, 10.1
@@ -91,6 +92,7 @@ public class RtpHandler {
             }
             break;
         case JPEG:
+        case JPEG_ATTACK:
         default:
             break;
         }
@@ -139,6 +141,7 @@ public class RtpHandler {
         case JPEG:
             image = jpegEncryptionHandler.encrypt(jpegImage);
             break;
+        case JPEG_ATTACK:
         case SRTP:
         default:
             image = jpegImage;
@@ -168,6 +171,7 @@ public class RtpHandler {
             packetData = srtpHandler.transformToSrtp(packet);
             break;
         case JPEG:
+        case JPEG_ATTACK:
         default:
             break;
         }
@@ -209,6 +213,12 @@ public class RtpHandler {
                 image = decryptedImage;
             }
             break;
+        case JPEG_ATTACK:
+            decryptedImage = jpegEncryptionHandler.replaceAttackDecryption(image);
+            if (decryptedImage != null) {
+                image = decryptedImage;
+            }
+            break;
         case SRTP:
         default:
             break;
@@ -236,6 +246,7 @@ public class RtpHandler {
             }
             break;
         case JPEG:
+        case JPEG_ATTACK:
         default:
             break;
         }
@@ -315,6 +326,7 @@ public class RtpHandler {
             }
             break;
         case JPEG:
+        case JPEG_ATTACK:
             /* Use pre-shared key and salt to avoid key management and
              * session initialization with a protocol.
              */

--- a/src/Server.java
+++ b/src/Server.java
@@ -183,6 +183,9 @@ public class Server extends JFrame implements ActionListener, ChangeListener {
       case "SRTP":
         mode = RtpHandler.EncryptionMode.SRTP;
         break;
+      case "JPEG":
+        mode = RtpHandler.EncryptionMode.JPEG;
+        break;
       default:
         break;
       }
@@ -570,6 +573,16 @@ public class Server extends JFrame implements ActionListener, ChangeListener {
     gbc.weightx = 1;
     gbc.fill = GridBagConstraints.HORIZONTAL;
     panel.add(e_srtp, gbc);
+
+    JRadioButton e_jpeg = new JRadioButton("JPEG");
+    e_jpeg.addItemListener(this::radioButtonSelected);
+    encryptionButtons.add(e_jpeg);
+    gbc = new GridBagConstraints();
+    gbc.gridx = 3;
+    gbc.gridy = 2;
+    gbc.weightx = 1;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    panel.add(e_jpeg, gbc);
   }
 
   /** Get the metadata from a video file.


### PR DESCRIPTION
Implement an example of JPEG encryption.
The encrypted parts of the images are the quantization tables.

The encryption mechanism is insecure because the encrypted quantization table simply can be exchanged with the example tables from the JPEG standard (Annex K.1).

Client and Server both get options for using the JPEG encryption with pre-shared keys.
The Client also gets the option to attack the JPEG encryption in the described way.

The proposed encryption mechanism is only for instructional purposes and should not be used in real applications.

This PR does not include new TASKs.